### PR TITLE
Mdawn update to tf13 and aws3 174500350

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.31.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
+Terraform 0.13. Pin module version to ~> 3.X. Submit pull-requests to master branch.
+
+Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to terraform012 branch.
 
 Terraform 0.11. Pin module version to ~> 1.X. Submit pull-requests to terraform011 branch.
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ module "ecr_ci_myapp" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| terraform | ~> 0.13 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/examples/providers.tf
+++ b/examples/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 2.70"
-}

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.13.0"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.13"
 
   required_providers {
     aws = {


### PR DESCRIPTION
# [update TF & aws](https://www.pivotaltracker.com/story/show/174500350)

Changes proposed in this pull request:

- updates to TF `0.13` & provider to aws `3.0`
- updates precommit versions 
- replaces `providers.tf` with preferred `versions.tf`

**Note:** terratest is failing locally but CI is passing. 😑  Put a ticket in backlog to fix.