### PR TITLE
"ci: validate-tf rather than validate and TFDocs GHA"

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: validate
+name: validate-tf
 
 on:
   push:
@@ -9,5 +9,5 @@ on:
       - main
 
 jobs:
-  validate:
-    uses: trussworks/shared-actions/.github/workflows/validate.yml@main
+  validate-tf:
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         exclude: README.m(ark)?d(own)?
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.33.0
     hooks:
       - id: markdownlint
 
@@ -41,6 +41,6 @@ repos:
         args: ["markdown", "table", "--output-file", "README.md", "."]
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.77.1
     hooks:
       - id: terraform_fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -34,16 +34,13 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "v0.16.0"
     hooks:
-      - id: terraform_docs
-        args:
-          - --args=--config=.terraform-docs.yml
-      - id: terraform_fmt
+      - id: terraform-docs-go
+        args: ["markdown", "table", "--output-file", "README.md", "."]
 
-  - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.0
     hooks:
-      - id: golangci-lint
-        entry: golangci-lint run --fix --timeout 300s
+      - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform 0.13 and newer. Pin module version to ~> 3.X. Submit pull-requests to 
 
 Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to terraform012 branch.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 Creates an IAM user/group for CI to use to push images to ECR.
 
 Creates the following resources:
@@ -62,7 +62,7 @@ No modules.
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## Developer Setup
 


### PR DESCRIPTION
# [Update terraform module template to use terraform-docs' own hook](https://trello.com/c/0eThuK02/241-update-terraform-module-template-to-use-terraform-docs-own-hook)
# [Update terraform modules to use new validate-tf shared action](https://trello.com/c/i1sHKDjQ/243-update-terraform-modules-to-use-new-validate-tf-shared-action)

- ci: validate-tf instead of validate
- ci: terraform docs official action

