### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "ecr_ci_myapp" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 1.0 |
 | aws | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-## Terraform Versions
-
-Terraform 0.13 and newer. Pin module version to ~> 3.X. Submit pull-requests to master branch.
-
-Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to terraform012 branch.
-
 <!-- BEGIN_TF_DOCS -->
 Creates an IAM user/group for CI to use to push images to ECR.
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
